### PR TITLE
config.toml: add target configuration for "riscv64imac-unknown-none-elf"

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "riscv64imac-unknown-none-elf"


### PR DESCRIPTION
- This addition facilitates better integration and usage with IDEs like VSCode and RustRover.

Signed-off-by: Longbing Zheng <1211998648@qq.com>